### PR TITLE
Allow for numeric escape sequences

### DIFF
--- a/minify.lua
+++ b/minify.lua
@@ -324,11 +324,8 @@ function CreateLuaTokenStream(text)
 				local c2 = get()
 				if c2 == '\\' then
 					local c3 = get()
-					if not c3:match("%d") then
-						local esc = CharacterForEscape[c3]
-						if not esc then
-							error("Invalid Escape Sequence `"..c3.."`.")
-						end
+					if not(Digits[c3] or CharacterForEscape[c3]) then
+						error("Invalid Escape Sequence `"..c3.."`.")
 					end
 				elseif c2 == c1 then
 					break

--- a/minify.lua
+++ b/minify.lua
@@ -324,9 +324,11 @@ function CreateLuaTokenStream(text)
 				local c2 = get()
 				if c2 == '\\' then
 					local c3 = get()
-					local esc = CharacterForEscape[c3]
-					if not esc then
-						error("Invalid Escape Sequence `"..c3.."`.")
+					if not c3:match("%d") then
+						local esc = CharacterForEscape[c3]
+						if not esc then
+							error("Invalid Escape Sequence `"..c3.."`.")
+						end
 					end
 				elseif c2 == c1 then
 					break


### PR DESCRIPTION
Lua strings accept numerical escapes as a "\ddd" sequence, where
ddd is 1-3 decimal digits (see Lua Manual, "Lexical Conventions").

This patch makes the parser tolerate escape sequences starting
with a digit, copying them to the output as-is.
Note that they're not validated in this case.